### PR TITLE
Fix useCollection query-constraint type and add tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ["lint", "type-check", "test", "build"]
+        command: ["lint", "type-check", "test run", "build"]
 
     name: ${{ matrix.command }}
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ["lint", "type-check", "test run", "build"]
+        command: ["lint", "type-check", "test", "build"]
 
     name: ${{ matrix.command }}
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "type-check": "tsc --noEmit",
     "build": "tsup && tsc --emitDeclarationOnly && tsc-alias --verbose",
     "prepare": "pnpm clean && pnpm type-check && pnpm build",
-    "test": "echo \"No test specified\"",
+    "test": "vitest",
     "clean": "del-cli dist tsconfig.tsbuildinfo"
   },
   "author": "Thijs Koerselman",
@@ -55,6 +55,7 @@
     "eslint": "^9.18.0",
     "prettier": "^3.4.2",
     "prettier-plugin-jsdoc": "^1.3.2",
+    "react-test-renderer": "^18.2.0",
     "tsc-alias": "^1.8.10",
     "tsup": "^8.3.5",
     "typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 9.18.0
       '@testing-library/react-hooks':
         specifier: ^8.0.1
-        version: 8.0.1(@types/react@19.0.7)(react@18.2.0)
+        version: 8.0.1(@types/react@19.0.7)(react-test-renderer@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: ^19.0.7
         version: 19.0.7
@@ -39,6 +39,9 @@ importers:
       prettier-plugin-jsdoc:
         specifier: ^1.3.2
         version: 1.3.2(prettier@3.4.2)
+      react-test-renderer:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.2.0)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1965,10 +1968,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2957,6 +2956,16 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-shallow-renderer@16.15.0:
+    resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  react-test-renderer@18.3.1:
+    resolution: {integrity: sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==}
+    peerDependencies:
+      react: ^18.3.1
+
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -3043,6 +3052,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.24.0-canary-efb381bbf-20230505:
     resolution: {integrity: sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==}
@@ -4885,7 +4897,7 @@ snapshots:
       jest-haste-map: 29.7.0
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
@@ -5180,13 +5192,14 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@testing-library/react-hooks@8.0.1(@types/react@19.0.7)(react@18.2.0)':
+  '@testing-library/react-hooks@8.0.1(@types/react@19.0.7)(react-test-renderer@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       react: 18.2.0
       react-error-boundary: 3.1.4(react@18.2.0)
     optionalDependencies:
       '@types/react': 19.0.7
+      react-test-renderer: 18.3.1(react@18.2.0)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -5806,8 +5819,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.24.2
       '@esbuild/win32-x64': 0.24.2
 
-  escalade@3.1.1: {}
-
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -6220,7 +6231,7 @@ snapshots:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       jest-worker: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -6232,7 +6243,7 @@ snapshots:
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -6481,7 +6492,7 @@ snapshots:
       graceful-fs: 4.2.11
       invariant: 2.2.4
       jest-worker: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       nullthrows: 1.1.1
       walker: 1.0.8
     transitivePeerDependencies:
@@ -7037,6 +7048,19 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-shallow-renderer@16.15.0(react@18.2.0):
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.2.0
+      react-is: 18.3.1
+
+  react-test-renderer@18.3.1(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-is: 18.3.1
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      scheduler: 0.23.2
+
   react@18.2.0:
     dependencies:
       loose-envify: 1.4.0
@@ -7069,7 +7093,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.26.7
 
   regexpu-core@6.2.0:
     dependencies:
@@ -7136,6 +7160,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.24.0-canary-efb381bbf-20230505:
     dependencies:
@@ -7580,7 +7608,7 @@ snapshots:
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,24 @@
+import { vi } from "vitest";
+
+// Mock Firebase Firestore
+vi.mock("@react-native-firebase/firestore", () => {
+  const queryConstraintMock = {
+    _apply: vi.fn(),
+  };
+
+  const createQueryConstraint = () => ({
+    ...queryConstraintMock,
+  });
+
+  return {
+    default: () => ({
+      collection: vi.fn(),
+    }),
+    collection: vi.fn(),
+    query: vi.fn(),
+    limit: vi.fn().mockReturnValue(createQueryConstraint()),
+    where: vi.fn().mockReturnValue(createQueryConstraint()),
+    orderBy: vi.fn().mockReturnValue(createQueryConstraint()),
+    onSnapshot: vi.fn(),
+  };
+});

--- a/src/__tests__/use-collection.test.ts
+++ b/src/__tests__/use-collection.test.ts
@@ -1,23 +1,22 @@
 import { renderHook } from "@testing-library/react-hooks";
 import firestore, {
   collection,
-  query,
   where,
   orderBy,
   limit,
 } from "@react-native-firebase/firestore";
 import { useCollection } from "../use-collection";
-import type { DocumentData, CollectionReference } from "../firestore-types";
+import type { CollectionReference } from "../firestore-types";
 import { describe, it, expect } from "vitest";
 
 // Define a sample document type
-interface TodoItem extends DocumentData {
+type TodoItem = {
   id: string;
   title: string;
   completed: boolean;
   priority: number;
   dueDate: Date;
-}
+};
 
 describe("useCollection", () => {
   it("should have correct type inference", () => {

--- a/src/__tests__/use-collection.test.ts
+++ b/src/__tests__/use-collection.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from "@testing-library/react-hooks";
+import firestore, {
+  collection,
+  query,
+  where,
+  orderBy,
+  limit,
+} from "@react-native-firebase/firestore";
+import { useCollection } from "../use-collection";
+import type { DocumentData, CollectionReference } from "../firestore-types";
+import { describe, it, expect } from "vitest";
+
+// Define a sample document type
+interface TodoItem extends DocumentData {
+  id: string;
+  title: string;
+  completed: boolean;
+  priority: number;
+  dueDate: Date;
+}
+
+describe("useCollection", () => {
+  it("should have correct type inference", () => {
+    // This test is mainly for TypeScript type checking
+    const collectionRef = collection(
+      firestore(),
+      "todos"
+    ) as CollectionReference<TodoItem>;
+
+    // The actual test is that this compiles without type errors
+    const { result } = renderHook(() => useCollection<TodoItem>(collectionRef));
+
+    // TypeScript should infer this as: [FsMutableDocument<TodoItem>[], false] | [undefined, true]
+    const [docs, loading] = result.current;
+
+    if (!loading) {
+      // When not loading, docs should be FsMutableDocument<TodoItem>[]
+      const firstDoc = docs[0];
+      if (firstDoc) {
+        const _title: string = firstDoc.data.title; // Should compile
+        const _completed: boolean = firstDoc.data.completed; // Should compile
+        expect(typeof _title).toBe("string");
+        expect(typeof _completed).toBe("boolean");
+      }
+    }
+  });
+
+  it("should work with query constraints", () => {
+    const collectionRef = collection(
+      firestore(),
+      "todos"
+    ) as CollectionReference<TodoItem>;
+
+    // The actual test is that this compiles without type errors
+    const { result } = renderHook(() =>
+      useCollection<TodoItem>(
+        collectionRef,
+        where("completed", "==", false),
+        where("priority", ">", 1),
+        orderBy("dueDate", "asc"),
+        limit(10)
+      )
+    );
+
+    // TypeScript should infer this as: [FsMutableDocument<TodoItem>[], false] | [undefined, true]
+    const [docs, loading] = result.current;
+
+    if (!loading) {
+      // When not loading, docs should be FsMutableDocument<TodoItem>[]
+      const firstDoc = docs[0];
+      if (firstDoc) {
+        // Verify type inference for all fields
+        const _title: string = firstDoc.data.title;
+        const _completed: boolean = firstDoc.data.completed;
+        const _priority: number = firstDoc.data.priority;
+        const _dueDate: Date = firstDoc.data.dueDate;
+
+        // Type checks
+        expect(typeof _title).toBe("string");
+        expect(typeof _completed).toBe("boolean");
+        expect(typeof _priority).toBe("number");
+        expect(_dueDate).toBeInstanceOf(Date);
+      }
+    }
+  });
+});

--- a/src/__tests__/use-collection.test.ts
+++ b/src/__tests__/use-collection.test.ts
@@ -27,7 +27,7 @@ describe("useCollection", () => {
     ) as CollectionReference<TodoItem>;
 
     // The actual test is that this compiles without type errors
-    const { result } = renderHook(() => useCollection<TodoItem>(collectionRef));
+    const { result } = renderHook(() => useCollection(collectionRef));
 
     // TypeScript should infer this as: [FsMutableDocument<TodoItem>[], false] | [undefined, true]
     const [docs, loading] = result.current;
@@ -52,7 +52,7 @@ describe("useCollection", () => {
 
     // The actual test is that this compiles without type errors
     const { result } = renderHook(() =>
-      useCollection<TodoItem>(
+      useCollection(
         collectionRef,
         where("completed", "==", false),
         where("priority", ">", 1),

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -10,9 +10,18 @@ import { makeMutableDocument } from "./make-mutable-document";
 import type { FsMutableDocument } from "./types";
 import { getErrorMessage, isDefined } from "./utils";
 
+/**
+ * The @react-native-firebase/firestore query constraint functions where,
+ * orderBy, limit, etc. are incorrectly typed and are missing the `_apply`
+ * method.
+ *
+ * Exclude the `_apply` method to make the type checker happy.
+ */
+type QueryConstraints = (Omit<QueryConstraint, "_apply"> | undefined)[];
+
 export function useCollection<T extends DocumentData>(
   collectionRef: CollectionReference<T>,
-  ...queryConstraints: (QueryConstraint | undefined)[]
+  ...queryConstraints: QueryConstraints
 ): [FsMutableDocument<T>[], false] | [undefined, true] {
   const hasNoConstraints = queryConstraints.length === 0;
 
@@ -44,7 +53,7 @@ export function useCollection<T extends DocumentData>(
 
 export function useCollectionOnce<T extends DocumentData>(
   collectionRef: CollectionReference<T>,
-  ...queryConstraints: (QueryConstraint | undefined)[]
+  ...queryConstraints: QueryConstraints
 ): [FsMutableDocument<T>[], false] | [undefined, true] {
   const hasNoConstraints = queryConstraints.length === 0;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: ["./src/__tests__/setup.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
This PR adds tests for `useCollection` in order to reproduce a typing problem with the collection query constraints argument. Using `useCollection` with one or more query constraints would yield a typescript error that the `_apply` method is missing. This appears to be a bug in the `@react-native-firebase/firestore` types. This PR also fixes that.