### PR TITLE
Update usage README imports and type definitions for react native lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ map each to the appropriate type, as shown below.
 // db-refs.ts
 import {
   collection,
-  type CollectionReference,
+  FirebaseFirestoreTypes,
 } from "@react-native-firebase/firestore";
 import { db } from "./firestore";
 import { User, WishlistItem, Book } from "./types";
+
+type CollectionReference<T extends FirebaseFirestoreTypes.DocumentData> = FirebaseFirestoreTypes.CollectionReference<T>;
 
 export const refs = {
   /** For top-level collections it's easy */
@@ -60,7 +62,7 @@ export const refs = {
 Below is an example of how to use the hooks in a component:
 
 ```ts
-import { useDocument } from "@typed-firestore/react";
+import { useDocument } from "@typed-firestore/react-native";
 import { UpdateData } from "@react-native-firebase/firestore";
 
 export function DisplayName({userId}: {userId: string}) {

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ import {
   collection,
   FirebaseFirestoreTypes,
 } from "@react-native-firebase/firestore";
+import type { CollectionReference } from "@typed-firestore/react-native";
 import { db } from "./firestore";
 import { User, WishlistItem, Book } from "./types";
-
-type CollectionReference<T extends FirebaseFirestoreTypes.DocumentData> = FirebaseFirestoreTypes.CollectionReference<T>;
 
 export const refs = {
   /** For top-level collections it's easy */


### PR DESCRIPTION
The example in the README reflected the web library usage, whereas `react-native-firebase` handles things a bit differently, resulting in linter errors. 